### PR TITLE
Py3compatible2

### DIFF
--- a/examples/add-delete.py
+++ b/examples/add-delete.py
@@ -24,7 +24,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import, division, print_function, unicode_literals
 import numpy as np
+from builtins import zip
 from numpy import sin, cos, pi, sqrt
 from math import atan2
 import random
@@ -32,6 +34,7 @@ import pyglet
 from pyglet import gl
 from collections import namedtuple
 from operator import add
+#import pdb
 
 from numpy_ecs.global_allocator import GlobalAllocator
 from numpy_ecs.components import DefraggingArrayComponent as Component
@@ -133,10 +136,11 @@ def update_render_verts(render_verts,poly_verts,positions,rotator,indices=[]):
     #and simplified.  work it out on paper if you don't believe me.
     xs, ys, rs, xhelpers, yhelpers = (poly_verts[:,x] for x in range(5))
     pts = render_verts  
-
     #print 'shapes:',angles.shape
     pts[:,0] = xhelpers*cos_ts[indices]
     pts[:,1] = yhelpers*sin_ts[indices]
+    #IndexError: array used as indices= must be integer type. Sometime the  
+    # function runs with empty parameters as indices =[]
     pts[:,0] -= pts[:,1]                 
     pts[:,0] *= rs                
     pts[:,0] += xs                
@@ -165,6 +169,7 @@ def update_display(render_verts,colors):
 
 
 def add_some(n,n2=None,allocator=allocator):
+    #pdb.set_trace()
     '''add n random polygons to allocator
 
     There's two types of polygons. if only n is given, will distribute randomly.
@@ -178,9 +183,9 @@ def add_some(n,n2=None,allocator=allocator):
       a = random.random()
       n1 = int(n*a)
       n2 = n-n1
-    else:
+    else: 
       n1 = n
-      n2 = 0
+      n2 = 0 #chemsed comment: it doesn't seem to work as intended
 
     positions = [(x*width,y*height,z) for x,y,z in np.random.random((n1,3))]
     rs = [r*50 for r in np.random.random(n1)] 
@@ -204,14 +209,18 @@ def add_some(n,n2=None,allocator=allocator):
 
 
 def delete_some(n,allocator=allocator):
-    guids = random.sample(allocator.guids,n)
+    #pdb.set_trace()
+    guids = random.sample(allocator.guids,n) 
+    #Value Error: sample (102,101) larger than population (4)
+    #Something is wrong with the guids and _next_guid method in global_allocator.py
+    # I noticed that deleting an element in tuple leave them to "None" at the index
     for guid in guids:
         allocator.delete(guid)
 
 
 
 if __name__ == '__main__':
-
+    #pdb.set_trace()
     width, height = 640,480
     window = pyglet.window.Window(width, height,vsync=False)
     #window = pyglet.window.Window(fullscreen=True,vsync=False)
@@ -227,8 +236,9 @@ if __name__ == '__main__':
 
     get_sections = allocator.selectors_from_component_query
 
-    @window.event
+   
     def on_draw():
+        #pdb.set_trace()
         window.clear()
 
         allocator._defrag()
@@ -241,6 +251,7 @@ if __name__ == '__main__':
         broadcast = ('position__to__poly_verts',)
         sections = get_sections(render_verts + broadcast)
         indices = sections.pop(broadcast[0])
+
         update_render_verts(*(sections[name] for name in render_verts),indices=indices)
 
         draw =('render_verts','color')
@@ -250,8 +261,8 @@ if __name__ == '__main__':
         fps_display.draw()
 
     pyglet.clock.schedule(lambda _: None)
+    #pdb.set_trace()
     pyglet.clock.schedule_interval(lambda x,*y: add_some(*y),1,2)
+    #pdb.set_trace()
     pyglet.clock.schedule_interval(lambda x,*y: delete_some(*y),2,4)
     pyglet.app.run()
-
-

--- a/examples/animated_test.py
+++ b/examples/animated_test.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 import numpy as np
 from numpy import sin, cos, pi, sqrt
+from builtins import zip
 from math import atan2
 import pyglet
 from pyglet import gl
@@ -56,7 +57,7 @@ def wind_pts(pts,reshape=False):
     '''take clockwise or counter clockwise points and wind them as would
     be needed for rendering as triangle strips'''
     if reshape:
-        pts = zip(pts[::3],pts[1::3],pts[2::3])
+        pts = list(zip(pts[::3],pts[1::3],pts[2::3]))
     l = len(pts)
     cw = pts[:l//2]
     ccw = pts[l//2:][::-1]

--- a/examples/color_change_test.py
+++ b/examples/color_change_test.py
@@ -29,6 +29,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
 import numpy as np
+from builtins import zip
 from numpy import sin, cos, pi, sqrt
 from math import atan2
 import pyglet

--- a/examples/compare.py
+++ b/examples/compare.py
@@ -62,7 +62,7 @@ def array_rotate(initiald):
 
     #flatten and return as a tuple for vertbuffer
     #return tuple(map(int,[val for subl in pts for val in subl]))
-    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), )
+    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), ) #it say reduce is not defined
     return pts.astype(np.int32)
 
 for n in [5,10,25,50,100,500,1000]:
@@ -71,11 +71,14 @@ for n in [5,10,25,50,100,500,1000]:
   start = time.time()
   trash = list_rotate(lst)
   end = time.time()
-  print "did list of %s in %s" % (n, end-start)
+  #compatibility python2/3 issue here
+  #print "did list of %s in %s" % (n, end-start)
+  print("did list of", n, "in", end-start)
 
   start = time.time()
   trash = array_rotate(arr)
   end = time.time()
-  print "did array of %s in %s" % (n, end-start)
-
-  print "\n"
+  # compatibility python2/3 issue here
+  # print "did array of %s in %s" % (n, end-start)
+  # print "\n"
+  print("did array of", n, "in", end-start)

--- a/examples/compare.py
+++ b/examples/compare.py
@@ -19,6 +19,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 '''
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import map
 import numpy as np
 from math import pi, sin, cos,atan2,sqrt
 from functools import reduce
@@ -63,7 +65,7 @@ def array_rotate(initiald):
 
     #flatten and return as a tuple for vertbuffer
     #return tuple(map(int,[val for subl in pts for val in subl]))
-    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), ) #it say reduce is not defined
+    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), )
     return pts.astype(np.int32)
 
 for n in [5,10,25,50,100,500,1000]:
@@ -72,14 +74,9 @@ for n in [5,10,25,50,100,500,1000]:
   start = time.time()
   trash = list_rotate(lst)
   end = time.time()
-  #compatibility python2/3 issue here
-  #print "did list of %s in %s" % (n, end-start)
-  print("did list of", n, "in", end-start)
+  print("did list of {} in {:.6f}".format(n, end-start))
 
   start = time.time()
   trash = array_rotate(arr)
   end = time.time()
-  # compatibility python2/3 issue here
-  # print "did array of %s in %s" % (n, end-start)
-  # print "\n"
-  print("did array of", n, "in", end-start)
+  print("did array of {} in {:.6f} \n".format(n, end-start))

--- a/examples/compare.py
+++ b/examples/compare.py
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 import numpy as np
 from math import pi, sin, cos,atan2,sqrt
+from functools import reduce
 import time
 
 def gen_initiald(n):

--- a/examples/first.py
+++ b/examples/first.py
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 '''
 from __future__ import absolute_import, division, print_function, unicode_literals
-from builtins import map
+from builtins import map, zip
 import numpy as np
 import pyglet
 from pyglet import gl
@@ -133,12 +133,9 @@ n=1000
 positions = [(x*width,y*height) for x,y in np.random.random((n,2))]
 poly_args = [(r*50,int(m*10)+3) for r,m in np.random.random((n,2))] 
 colors = [list(map(lambda x: int(x*255),vals)) for vals in np.random.random((n,3))]
-#debug: colors is a list of map object, so a list of iterator, I changed that to a list of list
 ents = [Convex(polyOfN(*pargs),position=pos, color=col) for pargs,pos,col in zip(poly_args,positions,colors)]
-# TypeError: unsupported operand type(s) for *: 'map' and 'int'
 angles= [0]*n
 rates = list(np.random.random(n)*.02)
-pdb.set_trace()
 @window.event
 def on_draw():
     global angle

--- a/examples/first.py
+++ b/examples/first.py
@@ -31,7 +31,7 @@ from pyglet import gl
 from pyglet.graphics import Batch
 from math import pi, sin, cos,atan2,sqrt
 import time 
-
+import pdb
 #Limit run time for profiling
 run_for = 15 #seconds to run test for
 def done_yet(duration = run_for, start=time.time()):
@@ -103,13 +103,14 @@ class Convex(object):
         self.initial_data = [(pt[0],pt[1],sqrt(pt[0]**2+pt[1]**2),cos(atan2(pt[1],pt[0])),sin(atan2(pt[1],pt[0]))) for pt in wound]
         verts = self.rotate(0)
         self.n=len(verts)//2
+        print(verts)
         self.set_colors()
         self.vertlist = main_batch.add(self.n, gl.GL_TRIANGLE_STRIP,None,
   ('v2i,',verts),('c3b',self.colors))
 
     def set_colors(self):
         self.colors = self.color*self.n
- 
+
     def rotate(self,theta):
         px, py = self.position
         initiald = self.initial_data
@@ -127,12 +128,12 @@ class Convex(object):
         ##print(self.vertlist.colors)
         self.vertlist.colors=self.colors
 
-
-n=1000
+#pdb.set_trace()
+n=3
 positions = [(x*width,y*height) for x,y in np.random.random((n,2))]
 poly_args = [(r*50,int(m*10)+3) for r,m in np.random.random((n,2))] 
-colors = [map(lambda x: int(x*255),vals) for vals in np.random.random((n,3))]
-
+colors = [list(map(lambda x: int(x*255),vals)) for vals in np.random.random((n,3))]
+#debug: colors is a list of map object, so a list of iterator, I changed that to a list of list
 ents = [Convex(polyOfN(*pargs),position=pos, color=col) for pargs,pos,col in zip(poly_args,positions,colors)]
 # TypeError: unsupported operand type(s) for *: 'map' and 'int'
 angles= [0]*n

--- a/examples/first.py
+++ b/examples/first.py
@@ -30,7 +30,7 @@ from pyglet import gl
 from pyglet.graphics import Batch
 from math import pi, sin, cos,atan2,sqrt
 import time 
-import pdb
+
 
 #Limit run time for profiling
 run_for = 15 #seconds to run test for

--- a/examples/first.py
+++ b/examples/first.py
@@ -59,7 +59,7 @@ def draw():
 
     main_batch.draw()
 
-#helper hunction for making polygons
+#helper function for making polygons
 def polyOfN(radius,n):
     r=radius
     if n < 3:
@@ -103,7 +103,6 @@ class Convex(object):
         self.initial_data = [(pt[0],pt[1],sqrt(pt[0]**2+pt[1]**2),cos(atan2(pt[1],pt[0])),sin(atan2(pt[1],pt[0]))) for pt in wound]
         verts = self.rotate(0)
         self.n=len(verts)//2
-        print(verts)
         self.set_colors()
         self.vertlist = main_batch.add(self.n, gl.GL_TRIANGLE_STRIP,None,
   ('v2i,',verts),('c3b',self.colors))
@@ -128,7 +127,7 @@ class Convex(object):
         ##print(self.vertlist.colors)
         self.vertlist.colors=self.colors
 
-#pdb.set_trace()
+
 n=3
 positions = [(x*width,y*height) for x,y in np.random.random((n,2))]
 poly_args = [(r*50,int(m*10)+3) for r,m in np.random.random((n,2))] 
@@ -138,6 +137,7 @@ ents = [Convex(polyOfN(*pargs),position=pos, color=col) for pargs,pos,col in zip
 # TypeError: unsupported operand type(s) for *: 'map' and 'int'
 angles= [0]*n
 rates = list(np.random.random(n)*.02)
+pdb.set_trace()
 @window.event
 def on_draw():
     global angle

--- a/examples/first.py
+++ b/examples/first.py
@@ -134,7 +134,7 @@ poly_args = [(r*50,int(m*10)+3) for r,m in np.random.random((n,2))]
 colors = [map(lambda x: int(x*255),vals) for vals in np.random.random((n,3))]
 
 ents = [Convex(polyOfN(*pargs),position=pos, color=col) for pargs,pos,col in zip(poly_args,positions,colors)]
-
+# TypeError: unsupported operand type(s) for *: 'map' and 'int'
 angles= [0]*n
 rates = list(np.random.random(n)*.02)
 @window.event

--- a/examples/first.py
+++ b/examples/first.py
@@ -22,9 +22,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 '''
-
-
 from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import map
 import numpy as np
 import pyglet
 from pyglet import gl
@@ -32,6 +31,7 @@ from pyglet.graphics import Batch
 from math import pi, sin, cos,atan2,sqrt
 import time 
 import pdb
+
 #Limit run time for profiling
 run_for = 15 #seconds to run test for
 def done_yet(duration = run_for, start=time.time()):
@@ -72,7 +72,8 @@ class Convex(object):
     '''Convex polygons for rendering'''
     global main_batch
 
-    def __init__(self,pts, position=None, color=None, radius=0):
+    def __init__(self,pts, position=None, color=None, radius=0): 
+        # comment from chemsed: why the radius argument?
         if position is None:
           position = (width//2, height//2)
         self.position = position
@@ -128,7 +129,7 @@ class Convex(object):
         self.vertlist.colors=self.colors
 
 
-n=3
+n=1000
 positions = [(x*width,y*height) for x,y in np.random.random((n,2))]
 poly_args = [(r*50,int(m*10)+3) for r,m in np.random.random((n,2))] 
 colors = [list(map(lambda x: int(x*255),vals)) for vals in np.random.random((n,3))]
@@ -157,5 +158,3 @@ def on_draw():
 pyglet.clock.schedule(lambda _: None)
 
 pyglet.app.run()
-
-

--- a/examples/polygons.py
+++ b/examples/polygons.py
@@ -24,6 +24,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import zip
 import numpy as np
 from numpy import sin, cos, pi, sqrt
 from math import atan2
@@ -31,8 +33,7 @@ import pyglet
 from pyglet import gl
 from collections import namedtuple
 from operator import add
-
-from numpy_ecs.global_allocator import GlobalAllocator #ImportError: No module named 'numpy_ecs'
+from numpy_ecs.global_allocator import GlobalAllocator
 from numpy_ecs.components import DefraggingArrayComponent as Component
 
 dtype_tuple  = namedtuple('Dtype',('np','gl'))
@@ -223,5 +224,3 @@ if __name__ == '__main__':
     pyglet.clock.schedule(lambda _: None)
 
     pyglet.app.run()
-
-

--- a/examples/polygons.py
+++ b/examples/polygons.py
@@ -32,7 +32,7 @@ from pyglet import gl
 from collections import namedtuple
 from operator import add
 
-from numpy_ecs.global_allocator import GlobalAllocator
+from numpy_ecs.global_allocator import GlobalAllocator #ImportError: No module named 'numpy_ecs'
 from numpy_ecs.components import DefraggingArrayComponent as Component
 
 dtype_tuple  = namedtuple('Dtype',('np','gl'))

--- a/examples/second.py
+++ b/examples/second.py
@@ -168,7 +168,7 @@ def mass_rotate(initial_data,theta):
     pts[:,1] += pys
 
     #flatten and return as correct type
-    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), ) # reduce is not defined
+    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), )
     return pts.astype(vert_dtype.np_type)
 
 

--- a/examples/second.py
+++ b/examples/second.py
@@ -26,8 +26,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 '''
-
 from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import zip
 import numpy as np
 import pyglet
 from pyglet import gl
@@ -197,5 +197,3 @@ def on_draw():
 pyglet.clock.schedule(lambda _: None)
 
 pyglet.app.run()
-
-

--- a/examples/second.py
+++ b/examples/second.py
@@ -34,7 +34,7 @@ from pyglet import gl
 from math import pi, sin, cos,atan2,sqrt
 import time 
 from collections import namedtuple
-
+from functools import reduce
 
 #Keep datatypes between numpy and gl consistent
 dtype_tuple = namedtuple('Dtype',('np_type','gl_type'))

--- a/examples/second.py
+++ b/examples/second.py
@@ -168,7 +168,7 @@ def mass_rotate(initial_data,theta):
     pts[:,1] += pys
 
     #flatten and return as correct type
-    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), )
+    pts.shape = ( reduce(lambda xx,yy: xx*yy, pts.shape), ) # reduce is not defined
     return pts.astype(vert_dtype.np_type)
 
 

--- a/numpy_ecs/components.py
+++ b/numpy_ecs/components.py
@@ -44,7 +44,7 @@ class DefraggingArrayComponent(object):
       if dim == (1,):
         self._buffer = np.empty(size,dtype=dtype) #shape = (size,) not (size,1)
         self.resize = self._resize_singledim
-      elif dim > (1,):
+      elif dim > (1,): #dim is a tuple, not a scalar it seems
         self._buffer = np.empty((size,)+dim,dtype=dtype) #shape = (size,dim)
         self.resize = self._resize_multidim
       else:

--- a/numpy_ecs/components.py
+++ b/numpy_ecs/components.py
@@ -44,7 +44,7 @@ class DefraggingArrayComponent(object):
       if dim == (1,):
         self._buffer = np.empty(size,dtype=dtype) #shape = (size,) not (size,1)
         self.resize = self._resize_singledim
-      elif dim > 1:
+      elif dim > (1,):
         self._buffer = np.empty((size,)+dim,dtype=dtype) #shape = (size,dim)
         self.resize = self._resize_multidim
       else:

--- a/numpy_ecs/global_allocator.py
+++ b/numpy_ecs/global_allocator.py
@@ -72,7 +72,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # ]
 #
 #
-from table import Table, INDEX_SEPERATOR
+from numpy_ecs.table import Table, INDEX_SEPERATOR #I had to add numpy_ecs
 import numpy as np
 
 def verify_component_schema(allocation_schema):
@@ -226,7 +226,9 @@ class GlobalAllocator(object):
         known_names = self.names
         for x in query:
             if (sep not in x) and (x not in known_names):
-                print "%s in query is not valid"%x
+                #python2/3 compatibility
+                # print "%s in query is not valid"%x 
+                print(x, "in query is not valid")
                 return False
         return True
 

--- a/numpy_ecs/global_allocator.py
+++ b/numpy_ecs/global_allocator.py
@@ -74,7 +74,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 from __future__ import absolute_import, division, print_function, unicode_literals
 from builtins import zip, map
-from numpy_ecs.table import Table, INDEX_SEPERATOR #I had to add numpy_ecs
+from table import Table, INDEX_SEPERATOR
 import numpy as np
 
 def verify_component_schema(allocation_schema):

--- a/numpy_ecs/global_allocator.py
+++ b/numpy_ecs/global_allocator.py
@@ -72,6 +72,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # ]
 #
 #
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import zip, map
 from numpy_ecs.table import Table, INDEX_SEPERATOR #I had to add numpy_ecs
 import numpy as np
 
@@ -202,11 +204,11 @@ class GlobalAllocator(object):
 
        #defrag
        #print "defrag"
-       for name, (new_size, sources, targets) in zip(alloc_table.column_names,alloc_table.compress()):
+       for name, (new_size, sources, targets) in list(zip(alloc_table.column_names,alloc_table.compress())):
            #if name == 'component_1': print "working on component_1"
            component = component_dict[name]
            component.assert_capacity(new_size)
-           for source,target in zip(sources,targets):
+           for source,target in list(zip(sources,targets)):
                #if name == "component_1":
                #  print "moving",component[source],"to",target
                component[target] = component[source]
@@ -294,14 +296,14 @@ if __name__ == '__main__':
     to_add.append({'component_1':3,'component_3':(7,8,9),'component_2':((5,50),(6,60)),})
     to_add.append({'component_1':4,'component_3':(10,11,12),'component_2':((7,70),(8,80)),})
     to_add.append({'component_1':7,'component_3':(19,20,21),})
-    trash = map(allocator.add,to_add)
+    trash = list(map(allocator.add,to_add))
     #allocator.add(to_add2)
     allocator._defrag()
     #print "d1:",d1[:]
 
     to_add = []
     to_add.append({'component_1':8,'component_3':(22,23,24),})
-    trash = map(allocator.add,to_add)
+    trash = list(map(allocator.add,to_add))
     #allocator.add(to_add2)
     allocator._defrag()
     #print "d1:",d1[:]
@@ -310,7 +312,7 @@ if __name__ == '__main__':
     to_add.append({'component_1':5,'component_3':(13,14,15),'component_2':((9,90),(10,100)),})
     to_add.append({'component_1':6,'component_3':(16,17,18),'component_2':((11,110),(12,120)),})
     to_add.append({'component_1':9,'component_3':(25,26,27),})
-    trash = map(allocator.add,to_add)
+    trash = list(map(allocator.add,to_add))
     #allocator.add(to_add2)
     allocator._defrag()
     assert np.all(d1[:9] == np.array([1,2,3,4,5,6,7,8,9]))

--- a/numpy_ecs/global_allocator.py
+++ b/numpy_ecs/global_allocator.py
@@ -204,11 +204,11 @@ class GlobalAllocator(object):
 
        #defrag
        #print "defrag"
-       for name, (new_size, sources, targets) in list(zip(alloc_table.column_names,alloc_table.compress())):
+       for name, (new_size, sources, targets) in zip(alloc_table.column_names,alloc_table.compress()):
            #if name == 'component_1': print "working on component_1"
            component = component_dict[name]
            component.assert_capacity(new_size)
-           for source,target in list(zip(sources,targets)):
+           for source,target in zip(sources,targets):
                #if name == "component_1":
                #  print "moving",component[source],"to",target
                component[target] = component[source]
@@ -228,8 +228,6 @@ class GlobalAllocator(object):
         known_names = self.names
         for x in query:
             if (sep not in x) and (x not in known_names):
-                #python2/3 compatibility
-                # print "%s in query is not valid"%x 
                 print(x, "in query is not valid")
                 return False
         return True

--- a/numpy_ecs/table.py
+++ b/numpy_ecs/table.py
@@ -203,6 +203,7 @@ class Table(object):
         id_column = self.class_ids
         expressed_ids = filter(lambda x: x in id_column,known_ids)
         starts = map(id_column.index,expressed_ids)
+        # TypeError: object of type 'map' has no len()
         assert all(starts[x]<starts[x+1] for x in range(len(starts)-1)),\
             'id_column must be in same order as known_ids'
         stops = starts[1:]+[None]

--- a/numpy_ecs/table.py
+++ b/numpy_ecs/table.py
@@ -522,7 +522,9 @@ if __name__ == '__main__':
       except AssertionError:
         pass
       else:
-        print "Test failed: re-added staged guid"
+        #py2/3 print
+        # print "Test failed: re-added staged guid"
+        print("Test failed: re-added staged guid")
 
     for capacity, sources, targets in t.compress():
       assert capacity == 6, "capacity set to %s instead of 6" % alloc
@@ -546,11 +548,11 @@ if __name__ == '__main__':
     except AssertionError:
       pass
     else:
-      print "Test failed:  re-added allocated guid"
+      print("Test failed:  re-added allocated guid")
       
     #test adding an entity to a non-empty table
     t.stage_add(4,(10,10))
-    print "staged_adds:",t._staged_adds
+    print("staged_adds:",t._staged_adds)
 
     for n, (capacity, sources, targets) in enumerate(t.compress()):
       assert capacity == 16, "capacity set to %s instead of 16" % alloc

--- a/numpy_ecs/table.py
+++ b/numpy_ecs/table.py
@@ -32,7 +32,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
-
+from __future__ import absolute_import, division, print_function, unicode_literals
+from builtins import zip, map
 from collections import MutableMapping, Sequence
 from types import GeneratorType
 
@@ -202,7 +203,7 @@ class Table(object):
         known_ids = self.known_class_ids
         id_column = self.class_ids
         expressed_ids = filter(lambda x: x in id_column,known_ids)
-        starts = map(id_column.index,expressed_ids)
+        starts = list(map(id_column.index,expressed_ids))
         # TypeError: object of type 'map' has no len()
         assert all(starts[x]<starts[x+1] for x in range(len(starts)-1)),\
             'id_column must be in same order as known_ids'

--- a/numpy_ecs/table.py
+++ b/numpy_ecs/table.py
@@ -204,7 +204,6 @@ class Table(object):
         id_column = self.class_ids
         expressed_ids = filter(lambda x: x in id_column,known_ids)
         starts = list(map(id_column.index,expressed_ids))
-        # TypeError: object of type 'map' has no len()
         assert all(starts[x]<starts[x+1] for x in range(len(starts)-1)),\
             'id_column must be in same order as known_ids'
         stops = starts[1:]+[None]
@@ -397,7 +396,7 @@ class Table(object):
         #TODO make this a generator?
         ret = []
         for new_capacity, col_sources, col_targets in zip(
-                new_ends, zip(*sources), zip(*targets)):
+                new_ends, list(zip(*sources)), list(zip(*targets))):
             #print "sources:"
             col_sources = tuple((s for s in col_sources if slice_is_not_empty(s)))
             #print "targets:"
@@ -524,8 +523,6 @@ if __name__ == '__main__':
       except AssertionError:
         pass
       else:
-        #py2/3 print
-        # print "Test failed: re-added staged guid"
         print("Test failed: re-added staged guid")
 
     for capacity, sources, targets in t.compress():

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,5 @@ setup(
     url = "https://github.com/Permafacture/data-oriented-pyglet",
     install_requires = ['numpy','pyglet'],
     packages=['numpy_ecs',],
+    classifiers=["Programming Language :: Python :: 3"]
 )


### PR DESCRIPTION
Make the code compatible with python 3 and 2
- all scripts and modules have been converted apart of add-delete.py, animated_test.py and color_change_test.py since they were not mentionned in the README. 
- compatibility issues have been solved according to these sources and there are many choices about solving some issues (i.e:zip() and map()): 
  http://python-future.org/compatible_idioms.html
  http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html
- add a classifier in setup.py to indicate that the code is compatible with python 3.
